### PR TITLE
IAT-1230:  Converted to using log4j2 with a GELF logger for logging t…

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -43,10 +43,6 @@ zuul:
 logging:
   level:
     org:
-      springframework:
-        web: DEBUG
-        security:
-          saml: DEBUG
       opentestsystem:
         ap:
-          ivproxy: DEBUG
+          ivproxy: "debug"

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ plugins {
 }
 
 apply plugin: 'io.github.robwin.jgitflow'
+apply plugin: 'project-report'
 
 /***************************
  * dependency management
@@ -60,14 +61,18 @@ repositories {
     maven { url "https://airdev.jfrog.io/airdev/libs-snapshots/" }
 }
 
+configurations {
+    compile.exclude module: 'spring-boot-starter-logging'
+}
+
 dependencies {
-    compile 'org.opentestsystem.ap:ap-common:0.3.11'
+    compile 'org.opentestsystem.ap:ap-common:0.3.12-SNAPSHOT'
 
     compile 'org.springframework.boot:spring-boot-starter-actuator'
-
     compile 'org.springframework.boot:spring-boot-starter-security'
-    compile 'org.springframework.boot:spring-boot-starter-web'
     compile 'org.springframework.boot:spring-boot-starter-aop'
+    compile 'org.springframework.boot:spring-boot-starter-web'
+    compile 'org.springframework.boot:spring-boot-starter-log4j2'
     compile 'org.springframework.boot:spring-boot-starter-cache'
     compile 'org.springframework.boot:spring-boot-starter-data-redis'
 
@@ -82,6 +87,12 @@ dependencies {
     compile 'org.apache.commons:commons-lang3:3.5'
 
     compile 'com.google.guava:guava:22.0'
+
+    compile 'org.apache.logging.log4j:log4j-api:2.10.0'
+    compile 'org.apache.logging.log4j:log4j-core:2.10.0'
+    compile 'org.apache.logging.log4j:log4j-slf4j-impl:2.10.0'
+
+    compile 'com.lmax:disruptor:3.3.7'
 
     compile 'io.springfox:springfox-swagger2:2.6.1'
     compile 'io.springfox:springfox-swagger-ui:2.6.1'

--- a/src/main/java/org/opentestsystem/ap/ivproxy/ItemViewerProxyApplication.java
+++ b/src/main/java/org/opentestsystem/ap/ivproxy/ItemViewerProxyApplication.java
@@ -13,7 +13,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 package org.opentestsystem.ap.ivproxy;
 
 import org.springframework.boot.SpringApplication;
@@ -22,8 +21,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class ItemViewerProxyApplication {
 
-	public static void main(final String[] args) {
-		SpringApplication.run(ItemViewerProxyApplication.class, args);
-	}
+    static {
+        System.setProperty("log4j2.contextSelector", "org.apache.logging.log4j.core.async.AsyncLoggerContextSelector");
+    }
+
+    public static void main(final String[] args) {
+        SpringApplication.run(ItemViewerProxyApplication.class, args);
+    }
 }
 

--- a/src/main/resources/log4j2-spring.xml
+++ b/src/main/resources/log4j2-spring.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="warn">
+    <Properties>
+        <Property name="PID">????</Property>
+        <Property name="LOG_LEVEL_PATTERN">%5p</Property>
+        <Property name="CONSOLE_LOG_PATTERN">%clr{%d{yyyy-MM-dd HH:mm:ss.SSS}}{faint} %clr{${LOG_LEVEL_PATTERN}} %clr{${sys:PID}}{magenta} %clr{---}{faint} %clr{[%15.15t]}{faint} %clr{%-40.40c{1.}}{cyan} %clr{:}{faint} %m%n</Property>
+        <Property name="HOSTNAME">${env:HOSTNAME:-unknown}</Property>
+        <Property name="GRAYLOG_HOST">${env:GRAYLOG_HOST:-localhost}</Property>
+        <Property name="GRAYLOG_PORT">${env:GRAYLOG_PORT:-12201}</Property>
+    </Properties>
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT" immediateFlush="false">
+            <PatternLayout pattern="${sys:CONSOLE_LOG_PATTERN}" />
+        </Console>
+        <Socket name="Graylog" protocol="udp" host="${GRAYLOG_HOST}" port="${GRAYLOG_PORT}" immediateFlush="false">
+            <GelfLayout host="${HOSTNAME}" compressionType="ZLIB" compressionThreshold="1024">
+                <KeyValuePair key="application" value="ivp"/>
+            </GelfLayout>
+        </Socket>
+    </Appenders>
+    <Loggers>
+        <Logger name="org.apache.catalina.startup.DigesterFactory" level="error" />
+        <Logger name="org.apache.catalina.util.LifecycleBase" level="error" />
+        <Logger name="org.apache.coyote.http11.Http11NioProtocol" level="warn" />
+        <logger name="org.apache.sshd.common.util.SecurityUtils" level="warn"/>
+        <Logger name="org.apache.tomcat.util.net.NioSelectorPool" level="warn" />
+        <Logger name="org.crsh.plugin" level="warn" />
+        <logger name="org.crsh.ssh" level="warn"/>
+        <Logger name="org.eclipse.jetty.util.component.AbstractLifeCycle" level="error" />
+        <Logger name="org.hibernate.validator.internal.util.Version" level="warn" />
+        <Logger name="org.springframework.boot.actuate.autoconfigure.CrshAutoConfiguration" level="warn"/>
+        <Logger name="org.springframework.boot.actuate.endpoint.jmx" level="warn"/>
+        <Logger name="org.thymeleaf" level="warn"/>
+
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="Graylog"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<configuration debug="false">
-    <include resource="iat-centralized-logger.xml"/>
-</configuration>


### PR DESCRIPTION
…o Graylog.

__Summary of Changes__
- using log4j 2 now instead of logback
- using log4j 2 async appenders, the Graylog logging may not be async, kind of cool to log in a non-blocking way
- using a log4j 2 layout specific to Graylog (GELF - graylog extended log format)